### PR TITLE
Refactor/shorten validate params

### DIFF
--- a/app/controllers/api/v1/responses_controller.rb
+++ b/app/controllers/api/v1/responses_controller.rb
@@ -55,7 +55,7 @@ class Api::V1::ResponsesController < ApplicationController
 
     if response.errors.full_messages.length == 0
       response.save
-      create_update_answers(response, params[:scores]) if params[:scores]
+      create_answers(response, params[:scores]) if params[:scores]
 
       if is_submitted
         items = get_items(response)
@@ -118,7 +118,7 @@ class Api::V1::ResponsesController < ApplicationController
     response.validate_params(params, 'update')
     if response.errors.full_messages.length == 0
       response.save
-      create_update_answers(response, params[:scores]) if params[:scores].present?
+      update_answers(response, params[:scores]) if params[:scores].present?
       notify_instructor_on_difference(response) if response.is_submitted == true && was_submitted == false
       render json: 'Your response was successfully saved.', status: :ok
     else


### PR DESCRIPTION
validate_params method has been refractored in the Response model to improve readability and maintainability. The method has been broken down into several smaller, focused methods, each handling a specific part of the parameter validation process. This change enhances the separation of concerns and makes the code easier to manage and debug.
Changes include:+

    assign_map_id_from_params to set the map_id based on action.
    set_and_validate_response_map to ensure the response_map exists.
    set_response_attributes to assign additional attributes from params.
    action_specific_validation to route validation based on action type.
    validate_create_conditions and validate_update_conditions to handle specific checks for creation and update actions.
    -validate_submission_status to update and check the submission status during updates.
    These improvements aim to make the validation logic more intuitive and structured, facilitating easier updates and error handling in the future.

