### PR TITLE
Split create_update_answers method in create_answers and update_answers

### DIFF
--- a/app/controllers/api/v1/responses_controller.rb
+++ b/app/controllers/api/v1/responses_controller.rb
@@ -55,7 +55,7 @@ class Api::V1::ResponsesController < ApplicationController
 
     if response.errors.full_messages.length == 0
       response.save
-      create_update_answers(response, params[:scores]) if params[:scores]
+      create_answers(response, params[:scores]) if params[:scores]
 
       if is_submitted
         items = get_items(response)
@@ -118,7 +118,7 @@ class Api::V1::ResponsesController < ApplicationController
     response.validate_params(params, 'update')
     if response.errors.full_messages.length == 0
       response.save
-      create_update_answers(response, params[:scores]) if params[:scores].present?
+      update_answers(response, params[:scores]) if params[:scores].present?
       notify_instructor_on_difference(response) if response.is_submitted == true && was_submitted == false
       render json: 'Your response was successfully saved.', status: :ok
     else


### PR DESCRIPTION
This pull request introduces a clear separation between the logic for creating and updating answer records associated with responses. Previously, a single method create_update_answers handled both creation and updating, which worked well but did not align with the single-responsibility principle.

The changes split this functionality into two distinct methods: create_answers and update_answers. This ensures that each method has a single responsibility and improves the overall readability and maintainability of the codebase.

Key Changes:

create_answers: Iterates through provided answers and creates new Answer records only if they do not already exist.
update_answers: Specifically targets existing Answer records and applies updates, ensuring that the state of an Answer is kept consistent and up-to-date with the latest response.

By refactoring this logic, we also enhance error handling and make debugging more straightforward. These changes are expected to facilitate future extensions of the response and answer features without adding complexity to the existing logic.
